### PR TITLE
Added Link to Material for training new Managers

### DIFF
--- a/Transitioning to Management.md
+++ b/Transitioning to Management.md
@@ -134,6 +134,8 @@ As a leader of a product development team you might have a PM that you’re work
 
 - [What’s Your Learning Stack?](https://mystudentvoices.com/whats-your-learning-stack-55f8639c3d56) - by Mattan Griffel and Álvaro Sanmartín. Takeaway: Analogous to a tech stack, a learning stack codifies how learning is done in an org.
 
+- [Google’s new manager training](https://rework.withgoogle.com/guides/managers-develop-and-support-managers/steps/review-googles-new-manager-training/) - by re:Work (https://rework.withgoogle.com/) : The training material Google uses to help transition an Individual contributor to a Manager. 
+
 ### The VP of Engineering Role
 
 - [Hire a VP of Engineering](https://a16z.com/2017/05/26/hiring-vp-engineering-why-what/) - by Martin Casado. Takeaway: A VPE is responsible for product planning, building the engineering team and culture, ensuring execution, maintaining morale, delivering quality releases on time.


### PR DESCRIPTION
Added link to Google's new Manager training. This is helpful for teams / individuals that need support from learning how Google attempts transition of an Individual contributor to a new Manager. 