### PR TITLE
Update CONTRIBUTING.md to fix SSL error to title-case link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Please ensure your pull request adheres to the following guidelines:
 - Takeaways should avoid sub-bullets and be complete sentences. 
 - Use **quotation marks** when you're quoting verbatim.
 - Make **one individual pull request per each new entry/suggestion**.
-- Use [title-casing](http://titlecapitalization.com) (AP style), regardless of the style used by the original article.
+- Use [title-casing](https://titlecaseconverter.com) (AP style), regardless of the style used by the original article.
 - Add link additions in **alphabetical order**. 
   - Disregard articles (**the/an/a**) coming at the beginning of titles and use the next word.
 - New categories or improvements to the existing categorization are welcome.


### PR DESCRIPTION
I found that the title casing link has a SSL certificate privacy error (attached screenshot). So replacing it with a site that is SSL enabled and also has title case converter built-in. Having said that I maybe missing something, so please let me know if that is the case! 

Thanks for this wonderful resource :) 

<img width="1660" alt="Screen Shot 2021-05-06 at 1 23 49 PM" src="https://user-images.githubusercontent.com/3390906/117361359-c9c99900-ae6e-11eb-91c9-3d5064ab3f79.png">
